### PR TITLE
Update React

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "graphql": "^14.0.2",
     "next": "^7.0.2",
     "next-with-apollo": "^3.3.0",
-    "react": "^16.6.3",
+    "react": "^16.7.0-alpha.2",
     "react-apollo": "^2.3.2",
-    "react-dom": "^16.6.3"
+    "react-dom": "^16.7.0-alpha.2"
   }
 }


### PR DESCRIPTION
Hooks are only supported in the alpha releases.